### PR TITLE
fixed small typo in readme ('test' -> 'text')

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Scraper.new.get_page
 
 Once your file looks like the code above, run the file with `ruby lib/scraper.rb` in your terminal. Once you hit your binding, type the `doc` variable into the terminal and you should see the HTML document, retrieved for us by Nokogiri and open-uri. You should see something like this:
 
->Note: When you hit the pry, you may end up with a prompt that looks like this `:`. That just means there's a lot of test and you can scroll up and down using the arrow keys. If you need to escape this prompt so you can type in `doc`, then you simply have to press `q` or the `esc` key. 
+>Note: When you hit the pry, you may end up with a prompt that looks like this `:`. That just means there's a lot of text and you can scroll up and down using the arrow keys. If you need to escape this prompt so you can type in `doc`, then you simply have to press `q` or the `esc` key. 
 
 ![](http://readme-pics.s3.amazonaws.com/Screen%20Shot%202015-08-20%20at%204.25.06%20PM.png)
 


### PR DESCRIPTION
Fixed a small typo. Said "test" when it should have said "text":

"Note: When you hit the pry, you may end up with a prompt that looks like this `:`. That just means there's a lot of **test** [now **text**] and you can scroll up and down using the arrow keys"